### PR TITLE
Authentication Implementation and Timestamp fix

### DIFF
--- a/exporters/metric/cortex/auth.go
+++ b/exporters/metric/cortex/auth.go
@@ -75,3 +75,33 @@ func (e *Exporter) addBasicAuth(req *http.Request) error {
 
 	return nil
 }
+
+// addBearerTokenAuth sets the Authorization header for bearer tokens using a bearer token
+// string or a bearer token file. To prevent the Exporter from potentially opening a
+// bearer token file on every request by calling this method, the Authorization header is
+// also added to the Config header map.
+func (e *Exporter) addBearerTokenAuth(req *http.Request) error {
+	// No need to add bearer token auth if the Authorization header is already set.
+	if _, exists := e.config.Headers["Authorization"]; exists {
+		return nil
+	}
+
+	// Use bearer token from bearer token file if it exists.
+	if e.config.BearerTokenFile != "" {
+		file, err := ioutil.ReadFile(e.config.BearerTokenFile)
+		if err != nil {
+			return ErrFailedToReadFile
+		}
+		bearerTokenString := "Bearer " + string(file)
+		req.Header.Set("Authorization", bearerTokenString)
+		return nil
+	}
+
+	// Otherwise, use bearer token field.
+	if e.config.BearerToken != "" {
+		bearerTokenString := "Bearer " + e.config.BearerToken
+		req.Header.Set("Authorization", bearerTokenString)
+	}
+
+	return nil
+}

--- a/exporters/metric/cortex/auth.go
+++ b/exporters/metric/cortex/auth.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cortex

--- a/exporters/metric/cortex/auth.go
+++ b/exporters/metric/cortex/auth.go
@@ -13,3 +13,65 @@
 // limitations under the License.
 
 package cortex
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+var (
+	// ErrNoBasicAuthUsername occurs when no username was provided for basic
+	// authentication.
+	ErrNoBasicAuthUsername = fmt.Errorf("No username provided for basic authentication")
+
+	// ErrNoBasicAuthPassword occurs when no password or password file was provided for
+	// basic authentication.
+	ErrNoBasicAuthPassword = fmt.Errorf("No password or password file provided for basic authentication")
+
+	// ErrFailedToReadFile occurs when a password / bearer token file exists, but could
+	// not be read.
+	ErrFailedToReadFile = fmt.Errorf("Failed to read password / bearer token file")
+)
+
+// addBasicAuth sets the Authorization header for basic authentication using a username
+// and a password / password file. To prevent the Exporter from potentially opening a
+// password file on every request by calling this method, the Authorization header is also
+// added to the Config header map.
+func (e *Exporter) addBasicAuth(req *http.Request) error {
+	// No need to add basic auth if it isn't provided or if the Authorization header is
+	// already set.
+	if _, exists := e.config.Headers["Authorization"]; exists {
+		return nil
+	}
+	if e.config.BasicAuth == nil {
+		return nil
+	}
+
+	// There must be an username for basic authentication.
+	username := e.config.BasicAuth["username"]
+	if username == "" {
+		return ErrNoBasicAuthUsername
+	}
+
+	// Use password from password file if it exists.
+	passwordFile := e.config.BasicAuth["password_file"]
+	if passwordFile != "" {
+		file, err := ioutil.ReadFile(passwordFile)
+		if err != nil {
+			return ErrFailedToReadFile
+		}
+		password := string(file)
+		req.SetBasicAuth(username, password)
+		return nil
+	}
+
+	// Use provided password.
+	password := e.config.BasicAuth["password"]
+	if password == "" {
+		return ErrNoBasicAuthPassword
+	}
+	req.SetBasicAuth(username, password)
+
+	return nil
+}

--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -16,6 +16,9 @@ package cortex
 
 import (
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 // createFile writes a file with a slice of bytes at a specified filepath.
@@ -25,4 +28,32 @@ func createFile(bytes []byte, filepath string) error {
 		return err
 	}
 	return nil
+}
+
+// TestAuthentication checks whether http requests are properly authenticated with either
+// bearer tokens or basic authentication in the addHeaders method.
+func TestAuthentication(t *testing.T) {
+	tests := []struct {
+		testName                      string
+		basicAuth                     map[string]string
+		basicAuthPasswordFileContents []byte
+		bearerToken                   string
+		bearerTokenFile               string
+		bearerTokenFileContents       []byte
+		expectedAuthHeaderValue       string
+		expectedError                 error
+	}{}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			// Set up a test server that runs a handler function when it receives a http
+			// request. The server writes the request's Authorization header to the
+			// response body.
+			handler := func(rw http.ResponseWriter, req *http.Request) {
+				authHeaderValue := req.Header.Get("Authorization")
+				rw.Write([]byte(authHeaderValue))
+			}
+			server := httptest.NewServer(http.HandlerFunc(handler))
+			defer server.Close()
+		})
+	}
 }

--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -15,6 +15,7 @@
 package cortex
 
 import (
+	"encoding/base64"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,19 @@ func TestAuthentication(t *testing.T) {
 		bearerTokenFileContents       []byte
 		expectedAuthHeaderValue       string
 		expectedError                 error
-	}{}
+	}{
+		{
+			testName: "Basic Auth with password",
+			basicAuth: map[string]string{
+				"username": "TestUser",
+				"password": "TestPassword",
+			},
+			expectedAuthHeaderValue: "Basic " + base64.StdEncoding.EncodeToString(
+				[]byte("TestUser:TestPassword"),
+			),
+			expectedError: nil,
+		},
+	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			// Set up a test server that runs a handler function when it receives a http

--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -95,6 +95,12 @@ func TestAuthentication(t *testing.T) {
 			expectedAuthHeaderValue: "",
 			expectedError:           ErrFailedToReadFile,
 		},
+		{
+			testName:                "Bearer Token",
+			bearerToken:             "testToken",
+			expectedAuthHeaderValue: "Bearer testToken",
+			expectedError:           nil,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {

--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -101,6 +101,19 @@ func TestAuthentication(t *testing.T) {
 			expectedAuthHeaderValue: "Bearer testToken",
 			expectedError:           nil,
 		},
+		{
+			testName:                "Bearer Token with bad bearer token file",
+			bearerTokenFile:         "missingBearerTokenFile",
+			expectedAuthHeaderValue: "",
+			expectedError:           ErrFailedToReadFile,
+		},
+		{
+			testName:                "Bearer Token with bearer token file",
+			bearerTokenFile:         "bearerTokenFile",
+			expectedAuthHeaderValue: "Bearer testToken",
+			bearerTokenFileContents: []byte("testToken"),
+			expectedError:           nil,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
@@ -123,6 +136,12 @@ func TestAuthentication(t *testing.T) {
 					require.Nil(t, err)
 					defer os.Remove(filepath)
 				}
+			}
+			if test.bearerTokenFile != "" && test.bearerTokenFileContents != nil {
+				filepath := "./" + test.bearerTokenFile
+				err := createFile(test.bearerTokenFileContents, filepath)
+				require.Nil(t, err)
+				defer os.Remove(filepath)
 			}
 
 			// Create a HTTP request and add headers to it through an Exporter. Since the

--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cortex

--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,43 @@ func TestAuthentication(t *testing.T) {
 			),
 			expectedError: nil,
 		},
+		{
+			testName: "Basic Auth with no username",
+			basicAuth: map[string]string{
+				"password": "TestPassword",
+			},
+			expectedAuthHeaderValue: "",
+			expectedError:           ErrNoBasicAuthUsername,
+		},
+		{
+			testName: "Basic Auth with no password",
+			basicAuth: map[string]string{
+				"username": "TestUser",
+			},
+			expectedAuthHeaderValue: "",
+			expectedError:           ErrNoBasicAuthPassword,
+		},
+		{
+			testName: "Basic Auth with password file",
+			basicAuth: map[string]string{
+				"username":      "TestUser",
+				"password_file": "passwordFile",
+			},
+			basicAuthPasswordFileContents: []byte("TestPassword"),
+			expectedAuthHeaderValue: "Basic " + base64.StdEncoding.EncodeToString(
+				[]byte("TestUser:TestPassword"),
+			),
+			expectedError: nil,
+		},
+		{
+			testName: "Basic Auth with bad password file",
+			basicAuth: map[string]string{
+				"username":      "TestUser",
+				"password_file": "missingPasswordFile",
+			},
+			expectedAuthHeaderValue: "",
+			expectedError:           ErrFailedToReadFile,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
@@ -69,6 +107,17 @@ func TestAuthentication(t *testing.T) {
 			}
 			server := httptest.NewServer(http.HandlerFunc(handler))
 			defer server.Close()
+
+			// Create the necessary files for tests.
+			if test.basicAuth != nil {
+				passwordFile := test.basicAuth["password_file"]
+				if passwordFile != "" && test.basicAuthPasswordFileContents != nil {
+					filepath := "./" + test.basicAuth["password_file"]
+					err := createFile(test.basicAuthPasswordFileContents, filepath)
+					require.Nil(t, err)
+					defer os.Remove(filepath)
+				}
+			}
 
 			// Create a HTTP request and add headers to it through an Exporter. Since the
 			// Exporter has an empty Headers map, authentication methods will be called.

--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -13,3 +13,16 @@
 // limitations under the License.
 
 package cortex
+
+import (
+	"io/ioutil"
+)
+
+// createFile writes a file with a slice of bytes at a specified filepath.
+func createFile(bytes []byte, filepath string) error {
+	err := ioutil.WriteFile(filepath, bytes, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/exporters/metric/cortex/cortex.go
+++ b/exporters/metric/cortex/cortex.go
@@ -396,10 +396,11 @@ func createLabelSet(record metric.Record, extras ...string) []*prompb.Label {
 	return res
 }
 
-// AddHeaders adds required headers as well as all headers in Header map to a http request.
-func (e *Exporter) addHeaders(req *http.Request) {
-	// Cortex expects Snappy-compressed protobuf messages. These two headers are hard-coded as they
-	// should be on every request.
+// addHeaders adds required headers, an Authorization header, and all headers in the
+// Config Headers map to a http request.
+func (e *Exporter) addHeaders(req *http.Request) error {
+	// Cortex expects Snappy-compressed protobuf messages. These three headers are
+	// hard-coded as they should be on every request.
 	req.Header.Add("X-Prometheus-Remote-Write-Version", "0.1.0")
 	req.Header.Add("Content-Encoding", "snappy")
 	req.Header.Set("Content-Type", "application/x-protobuf")
@@ -408,6 +409,15 @@ func (e *Exporter) addHeaders(req *http.Request) {
 	for name, field := range e.config.Headers {
 		req.Header.Add(name, field)
 	}
+
+	// Add Authorization header if it wasn't already set.
+	if _, exists := e.config.Headers["Authorization"]; !exists {
+		if err := e.addBasicAuth(req); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // buildMessage creates a Snappy-compressed protobuf message from a slice of TimeSeries.

--- a/exporters/metric/cortex/cortex.go
+++ b/exporters/metric/cortex/cortex.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
@@ -185,7 +186,7 @@ func (e *Exporter) ConvertToTimeSeries(checkpointSet export.CheckpointSet) ([]*p
 func createTimeSeries(record metric.Record, value apimetric.Number, extraLabels ...string) *prompb.TimeSeries {
 	sample := prompb.Sample{
 		Value:     value.CoerceToFloat64(record.Descriptor().NumberKind()),
-		Timestamp: record.EndTime().Unix(),
+		Timestamp: record.EndTime().UnixNano() / int64(time.Millisecond),
 	}
 
 	labels := createLabelSet(record, extraLabels...)

--- a/exporters/metric/cortex/cortex.go
+++ b/exporters/metric/cortex/cortex.go
@@ -412,6 +412,9 @@ func (e *Exporter) addHeaders(req *http.Request) error {
 
 	// Add Authorization header if it wasn't already set.
 	if _, exists := e.config.Headers["Authorization"]; !exists {
+		if err := e.addBearerTokenAuth(req); err != nil {
+			return err
+		}
 		if err := e.addBasicAuth(req); err != nil {
 			return err
 		}

--- a/exporters/metric/cortex/cortex.go
+++ b/exporters/metric/cortex/cortex.go
@@ -255,7 +255,7 @@ func convertFromMinMaxSumCount(record metric.Record, minMaxSumCount aggregation.
 	}
 	countSample := prompb.Sample{
 		Value:     float64(count),
-		Timestamp: record.EndTime().Unix(), // Convert time to Unix (int64)
+		Timestamp: record.EndTime().UnixNano() / int64(time.Millisecond),
 	}
 
 	// Create labels, including metric name


### PR DESCRIPTION
This PR implements authentication through BasicAuth and Bearer tokens. Authentication is added on every request due to possibility of dynamic configuration reload and bearer token TTL.

Additionally, this PR changes the timestamps to be in milliseconds instead of seconds. This resolves the issue with data not showing up in Grafana.