### PR TITLE
[Cortex] Update conversion logic and update documentation

### DIFF
--- a/exporters/metric/cortex/example/README.md
+++ b/exporters/metric/cortex/example/README.md
@@ -18,7 +18,8 @@ docker-compose up -d
    admin/admin.
 
 3. Add Cortex as a data source by creating a new Prometheus data source is using
-   `http://localhost:9009/api/prom/` as the endpoint.
+   `http://cortex:9009/api/prom/` as the endpoint. Because Cortex is running in a docker container,
+   we use `cortex` as the url instead of `localhost`.
 
 4. View collected metrics in Grafana.
 

--- a/exporters/metric/cortex/example/docker-compose.yml
+++ b/exporters/metric/cortex/example/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     image: golang:1.14-alpine
     volumes:
       - .:/app
+      - ../:/cortex/
     working_dir: /app
     command: go run main.go
     ports:

--- a/exporters/metric/cortex/example/go.mod
+++ b/exporters/metric/cortex/example/go.mod
@@ -2,6 +2,9 @@ module go.opentelemetry.io/contrib/exporters/metric/cortex/example
 
 go 1.14
 
+// Replace to use the local version of the example project for testing
+replace go.opentelemetry.io/contrib/exporters/metric/cortex => ../cortex/
+
 require (
 	go.opentelemetry.io/contrib/exporters/metric/cortex v0.10.1
 	go.opentelemetry.io/contrib/exporters/metric/cortex/utils v0.10.1


### PR DESCRIPTION
I refactored the conversion logic to better match the documentation for aggregation kind. Primarily, I check for and convert Distributions before Sum. Previously, Distribution conversions would include the Sum generated by `convertFromSum`. [Prometheus](https://prometheus.io/docs/concepts/metric_types/#summary) expects the distribution sum to have the label `{"__name__": <metric-name>_sum}`. convertFromSum produces the label `{"__name__": <metric-name>}` which is correct, except in the case of distribution and histogram, thus the refactor. 

I also changed the Grafana data source to use `cortex` instead of `localhost` since it's running in a docker container now. 

I also added a replace statement to the example project so that the example runs off of the latest version of the example (whatever the user has just cloned). Right now, the released version of the exporter is missing an important bug fix that has been merged upstream and not released, so we did this to prevent the release cycle from impacting the functionality of the Example. 