### PR TITLE
Build both go-1.14 and go-1.15 in circleci with new custom executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,52 @@
 version: 2.1
-jobs:
-  build:
+executors:
+  current-go:
     docker:
       - image: circleci/golang:1.15
-
-    environment:
-      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
-
-    steps:
-      - checkout
-      - run: mkdir -p $TEST_RESULTS # create the test results directory
-
-      - restore_cache: # restores saved cache if no changes are detected since last run
-          keys:
-            - go-pkg-mod-{{ checksum "go.sum" }}
-
-      - run:
-          name: "Precommit and Coverage Report"
-          command: |
-            make ci
-            find . -name 'coverage.html' > "${TEST_RESULTS}/coverage.lst"
-            tar -n -cf - -T "${TEST_RESULTS}/coverage.lst" | tar -C "${TEST_RESULTS}" -xvf -
-
-      - save_cache:
-          key: go-pkg-mod-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
-
-      - store_artifacts:
-          path: /tmp/test-results
-          destination: opentelemetry-go-contrib-test-output
-
-      - store_test_results:
-          path: /tmp/test-results
+  prior-go:
+    docker:
+      - image: circleci/golang:1.14
   
+build-template: &build-template
+  environment:
+    TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+
+  steps:
+    - checkout
+    - run: mkdir -p $TEST_RESULTS # create the test results directory
+
+    - restore_cache: # restores saved cache if no changes are detected since last run
+        keys:
+          - go-pkg-mod-{{ checksum "go.sum" }}
+
+    - run:
+        name: "Precommit and Coverage Report"
+        command: |
+          make ci
+          find . -name 'coverage.html' > "${TEST_RESULTS}/coverage.lst"
+          tar -n -cf - -T "${TEST_RESULTS}/coverage.lst" | tar -C "${TEST_RESULTS}" -xvf -
+
+    - save_cache:
+        key: go-pkg-mod-{{ checksum "go.sum" }}
+        paths:
+          - "/go/pkg/mod"
+
+    - store_artifacts:
+        path: /tmp/test-results
+        destination: opentelemetry-go-contrib-test-output
+
+    - store_test_results:
+        path: /tmp/test-results
+
+jobs:
+  current-go:
+    executor: current-go
+    <<: *build-template
+
+  prior-go:
+    executor: prior-go
+    <<: *build-template
+
   integration:
 
     parameters:
@@ -71,7 +84,9 @@ workflows:
   version: 2.1
   build_and_test:
     jobs:
-      - build
+      - current-go
+      - prior-go
+      
   integration_test:
     jobs:
       - integration:


### PR DESCRIPTION
This PR changes the circleci build config to build the project in both go-1.15 and go-1.14 versions, to close issue #[239](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/239). This is to add support to maintain compatibility with both the current version of Go and the previous version.