### PR TITLE
fixed module declaration for macaron

### DIFF
--- a/instrumentation/gopkg.in/macaron.v1/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/go.mod
@@ -1,4 +1,4 @@
-module go.opentelemetry.io/contrib/instrumentation/macaron
+module go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1
 
 go 1.14
 


### PR DESCRIPTION
Simple bug fix, the module declaration was not previously updated to match the updated file hierarchy. Fixes issue #352