### PR TITLE
Add AWS X-Ray ID Generator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -99,6 +99,16 @@ updates:
       day: "sunday"
   -
     package-ecosystem: "gomod"
+    directory: "/idgenerator/aws"
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+  -
+    package-ecosystem: "gomod"
     directory: "/instrumentation/github.com/astaxie/beego/otelbeego"
     labels:
       - dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - `otelhttp.{Get,Head,Post,PostForm}` convenience wrappers for their `http` counterparts. (#390)
+- Add ID Generator for sending traces to AWS X-Ray. (#247)
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/otel v0.13.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/otel v0.13.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 go.opentelemetry.io/otel v0.13.0 h1:2isEnyzjjJZq6r2EKMsFj4TxiQiexsM04AVhwbR/oBA=
 go.opentelemetry.io/otel v0.13.0/go.mod h1:dlSNewoRYikTkotEnxdmuBHgzT+k/idJSfDv/FxEnOY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/idgenerator/aws/aws_xray_idgenerator.go
+++ b/idgenerator/aws/aws_xray_idgenerator.go
@@ -76,7 +76,3 @@ func getCurrentTimeHex() []uint8 {
 	}
 	return currentTimeHex
 }
-
-func intToHex(n int64) []byte {
-	return []byte(strconv.FormatInt(n, 16))
-}

--- a/idgenerator/aws/aws_xray_idgenerator.go
+++ b/idgenerator/aws/aws_xray_idgenerator.go
@@ -1,18 +1,16 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS'" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- *
- */
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package aws
 

--- a/idgenerator/aws/aws_xray_idgenerator.go
+++ b/idgenerator/aws/aws_xray_idgenerator.go
@@ -40,7 +40,10 @@ type xRayIDGenerator struct {
 func awsXRayIDGenerator() idGenerator {
 	gen := &xRayIDGenerator{}
 	var rngSeed int64
-	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
+	err := binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
+	if err != nil {
+		panic(err)
+	}
 	gen.randSource = rand.New(rand.NewSource(rngSeed))
 	return gen
 }
@@ -70,6 +73,9 @@ func (gen *xRayIDGenerator) NewTraceID() traceID {
 
 func getCurrentTimeHex() []uint8 {
 	currentTime := time.Now().Unix()
-	currentTimeHex, _ := hex.DecodeString(strconv.FormatInt(currentTime, 16))
+	currentTimeHex, err := hex.DecodeString(strconv.FormatInt(currentTime, 16))
+	if err != nil {
+		panic(err)
+	}
 	return currentTimeHex
 }

--- a/idgenerator/aws/aws_xray_idgenerator.go
+++ b/idgenerator/aws/aws_xray_idgenerator.go
@@ -70,9 +70,6 @@ func (gen *xRayIDGenerator) NewTraceID() traceID {
 
 func getCurrentTimeHex() []uint8 {
 	currentTime := time.Now().Unix()
-	currentTimeHex, err := hex.DecodeString(strconv.FormatInt(currentTime, 16))
-	if err != nil {
-		panic(err)
-	}
+	currentTimeHex, _ := hex.DecodeString(strconv.FormatInt(currentTime, 16))
 	return currentTimeHex
 }

--- a/idgenerator/aws/aws_xray_idgenerator.go
+++ b/idgenerator/aws/aws_xray_idgenerator.go
@@ -27,7 +27,8 @@ import (
 type spanID [8]byte
 type traceID [16]byte
 
-type idGenerator interface {
+// IDGenerator is an interface for generating new TraceIDs and SpanIDs
+type IDGenerator interface {
 	NewTraceID() traceID
 	NewSpanID() spanID
 }
@@ -37,7 +38,8 @@ type xRayIDGenerator struct {
 	randSource *rand.Rand
 }
 
-func awsXRayIDGenerator() idGenerator {
+// XRayIDGenerator returns an idGenerator used for sending traces to AWS X-Ray
+func XRayIDGenerator() IDGenerator {
 	gen := &xRayIDGenerator{}
 	var rngSeed int64
 	err := binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)

--- a/idgenerator/aws/aws_xray_idgenerator.go
+++ b/idgenerator/aws/aws_xray_idgenerator.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS'" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package aws
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"math/rand"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type spanID [8]byte
+type traceID [16]byte
+
+type idGenerator interface {
+	NewTraceID() traceID
+	NewSpanID() spanID
+}
+
+type xRayIDGenerator struct {
+	sync.Mutex
+	randSource *rand.Rand
+}
+
+func awsXRayIDGenerator() idGenerator {
+	gen := &xRayIDGenerator{}
+	var rngSeed int64
+	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
+	gen.randSource = rand.New(rand.NewSource(rngSeed))
+	return gen
+}
+
+// NewSpanID returns a non-zero span ID from a randomly-chosen sequence.
+func (gen *xRayIDGenerator) NewSpanID() spanID {
+	gen.Lock()
+	defer gen.Unlock()
+	sid := spanID{}
+	gen.randSource.Read(sid[:])
+	return sid
+}
+
+// NewTraceID returns a non-zero trace ID based on AWS X-Ray TraceID format.
+// (https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids)
+func (gen *xRayIDGenerator) NewTraceID() traceID {
+	gen.Lock()
+	defer gen.Unlock()
+
+	tid := traceID{}
+	currentTime := getCurrentTimeHex()
+	copy(tid[:4], currentTime)
+	gen.randSource.Read(tid[4:])
+
+	return tid
+}
+
+func getCurrentTimeHex() []uint8 {
+	currentTime := time.Now().Unix()
+	currentTimeHex, err := hex.DecodeString(strconv.FormatInt(currentTime, 16))
+	if err != nil {
+		panic(err)
+	}
+	return currentTimeHex
+}
+
+func intToHex(n int64) []byte {
+	return []byte(strconv.FormatInt(n, 16))
+}

--- a/idgenerator/aws/aws_xray_idgenerator.go
+++ b/idgenerator/aws/aws_xray_idgenerator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aws
+package aws // import "go.opentelemetry.io/contrib/idgenerator/aws"
 
 import (
 	crand "crypto/rand"

--- a/idgenerator/aws/aws_xray_idgenerator_test.go
+++ b/idgenerator/aws/aws_xray_idgenerator_test.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func (t traceID) convertTraceIDToHexString() string {
@@ -34,10 +36,9 @@ func TestAwsXRayTraceIdIsValidLength(t *testing.T) {
 	idg := awsXRayIDGenerator()
 	traceIDHex := idg.NewTraceID().convertTraceIDToHexString()
 	traceIDLength := len(traceIDHex)
+	expectedTraceIDLength := 32
 
-	if traceIDLength != 32 {
-		t.Errorf("TraceID has incorrect length. Got length of %d, expected 32", traceIDLength)
-	}
+	assert.Equal(t, traceIDLength, expectedTraceIDLength, "TraceID has incorrect length.")
 }
 
 func TestAwsXRayTraceIdIsUnique(t *testing.T) {
@@ -45,9 +46,7 @@ func TestAwsXRayTraceIdIsUnique(t *testing.T) {
 	traceID1 := idg.NewTraceID().convertTraceIDToHexString()
 	traceID2 := idg.NewTraceID().convertTraceIDToHexString()
 
-	if traceID1 == traceID2 {
-		t.Errorf("TraceID should be unique. Got TraceID1 = %s and TraceID2 = %s", traceID1, traceID2)
-	}
+	assert.NotEqual(t, traceID1, traceID2, "TraceID should be unique")
 }
 
 func TestAwsXRayTraceIdTimeStampInBounds(t *testing.T) {
@@ -65,33 +64,29 @@ func TestAwsXRayTraceIdTimeStampInBounds(t *testing.T) {
 		t.Error(err)
 	}
 
-	inLowerBound := previousTime <= currentTime
-	inUpperBound := currentTime <= nextTime
-
-	if !inLowerBound || !inUpperBound {
-		t.Errorf("TraceID is generated incorrectly with the wrong timestamp. Got epoch time %d, expected epoch time should be between %d and %d", currentTime, previousTime, currentTime)
-	}
+	assert.LessOrEqual(t, previousTime, currentTime, "TraceID is generated incorrectly with the wrong timestamp.")
+	assert.LessOrEqual(t, currentTime, nextTime, "TraceID is generated incorrectly with the wrong timestamp.")
 }
 
 func TestAwsXRayTraceIdIsNotNil(t *testing.T) {
 	var nilTraceID traceID
 	idg := awsXRayIDGenerator()
 	traceID := idg.NewTraceID()
-	isNil := bytes.Equal(traceID[:], nilTraceID[:])
 
-	if isNil == true {
-		t.Error("TraceID cannot be Nil.")
-	}
+	assert.False(t, bytes.Equal(traceID[:], nilTraceID[:]), "TraceID cannot be Nil.")
 }
 
 func TestAwsXRaySpanIdIsValidLength(t *testing.T) {
 	idg := awsXRayIDGenerator()
 	spanIDHex := idg.NewSpanID().cconvertSpanIDToHexString()
 	spanIDLength := len(spanIDHex)
+	expectedSpanIDLength := 16
 
 	if spanIDLength != 16 {
 		t.Errorf("SpanID has incorrect length. Got length of %d, expected 16", spanIDLength)
 	}
+
+	assert.Equal(t, spanIDLength, expectedSpanIDLength, "SpanID has incorrect length")
 }
 
 func TestAwsXRaySpanIdIsUnique(t *testing.T) {
@@ -99,18 +94,13 @@ func TestAwsXRaySpanIdIsUnique(t *testing.T) {
 	spanID1 := idg.NewSpanID().cconvertSpanIDToHexString()
 	spanID2 := idg.NewSpanID().cconvertSpanIDToHexString()
 
-	if spanID1 == spanID2 {
-		t.Errorf("SpanID should be unique. Got spanID1 = %s and spanID2 = %s", spanID1, spanID2)
-	}
+	assert.NotEqual(t, spanID1, spanID2, "SpanID should be unique")
 }
 
 func TestAwsXRaySpanIdIsNotNil(t *testing.T) {
 	var nilSpanID spanID
 	idg := awsXRayIDGenerator()
 	spanID := idg.NewSpanID()
-	isNil := bytes.Equal(spanID[:], nilSpanID[:])
 
-	if isNil == true {
-		t.Error("SpanID cannot be Nil.")
-	}
+	assert.False(t, bytes.Equal(spanID[:], nilSpanID[:]), "SpanID cannot be Nil.")
 }

--- a/idgenerator/aws/aws_xray_idgenerator_test.go
+++ b/idgenerator/aws/aws_xray_idgenerator_test.go
@@ -1,18 +1,16 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS'" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- *
- */
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package aws
 

--- a/idgenerator/aws/aws_xray_idgenerator_test.go
+++ b/idgenerator/aws/aws_xray_idgenerator_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS'" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package aws
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func (t traceID) convertTraceIDToHexString() string {
+	return hex.EncodeToString(t[:])
+}
+
+func (s spanID) cconvertSpanIDToHexString() string {
+	return hex.EncodeToString(s[:])
+}
+
+func TestAwsXRayTraceIdIsValidLength(t *testing.T) {
+	idg := awsXRayIDGenerator()
+	traceIDHex := idg.NewTraceID().convertTraceIDToHexString()
+	traceIDLength := len(traceIDHex)
+
+	if traceIDLength != 32 {
+		t.Errorf("TraceID has incorrect length. Got length of %d, expected 32", traceIDLength)
+	}
+}
+
+func TestAwsXRayTraceIdIsUnique(t *testing.T) {
+	idg := awsXRayIDGenerator()
+	traceID1 := idg.NewTraceID().convertTraceIDToHexString()
+	traceID2 := idg.NewTraceID().convertTraceIDToHexString()
+
+	if traceID1 == traceID2 {
+		t.Errorf("TraceID should be unique. Got TraceID1 = %s and TraceID2 = %s", traceID1, traceID2)
+	}
+}
+
+func TestAwsXRayTraceIdTimeStampInBounds(t *testing.T) {
+
+	idg := awsXRayIDGenerator()
+
+	previousTime := time.Now().Unix()
+
+	traceIDHex := idg.NewTraceID().convertTraceIDToHexString()
+	currentTime, err := strconv.ParseInt(traceIDHex[0:8], 16, 64)
+
+	nextTime := time.Now().Unix()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	inLowerBound := previousTime <= currentTime
+	inUpperBound := currentTime <= nextTime
+
+	if !inLowerBound || !inUpperBound {
+		t.Errorf("TraceID is generated incorrectly with the wrong timestamp. Got epoch time %d, expected epoch time should be between %d and %d", currentTime, previousTime, currentTime)
+	}
+}
+
+func TestAwsXRayTraceIdIsNotNil(t *testing.T) {
+	var nilTraceID traceID
+	idg := awsXRayIDGenerator()
+	traceID := idg.NewTraceID()
+	isNil := bytes.Equal(traceID[:], nilTraceID[:])
+
+	if isNil == true {
+		t.Error("TraceID cannot be Nil.")
+	}
+}
+
+func TestAwsXRaySpanIdIsValidLength(t *testing.T) {
+	idg := awsXRayIDGenerator()
+	spanIDHex := idg.NewSpanID().cconvertSpanIDToHexString()
+	spanIDLength := len(spanIDHex)
+
+	if spanIDLength != 16 {
+		t.Errorf("SpanID has incorrect length. Got length of %d, expected 16", spanIDLength)
+	}
+}
+
+func TestAwsXRaySpanIdIsUnique(t *testing.T) {
+	idg := awsXRayIDGenerator()
+	spanID1 := idg.NewSpanID().cconvertSpanIDToHexString()
+	spanID2 := idg.NewSpanID().cconvertSpanIDToHexString()
+
+	if spanID1 == spanID2 {
+		t.Errorf("SpanID should be unique. Got spanID1 = %s and spanID2 = %s", spanID1, spanID2)
+	}
+}
+
+func TestAwsXRaySpanIdIsNotNil(t *testing.T) {
+	var nilSpanID spanID
+	idg := awsXRayIDGenerator()
+	spanID := idg.NewSpanID()
+	isNil := bytes.Equal(spanID[:], nilSpanID[:])
+
+	if isNil == true {
+		t.Error("SpanID cannot be Nil.")
+	}
+}

--- a/idgenerator/aws/aws_xray_idgenerator_test.go
+++ b/idgenerator/aws/aws_xray_idgenerator_test.go
@@ -82,10 +82,6 @@ func TestAwsXRaySpanIdIsValidLength(t *testing.T) {
 	spanIDLength := len(spanIDHex)
 	expectedSpanIDLength := 16
 
-	if spanIDLength != 16 {
-		t.Errorf("SpanID has incorrect length. Got length of %d, expected 16", spanIDLength)
-	}
-
 	assert.Equal(t, spanIDLength, expectedSpanIDLength, "SpanID has incorrect length")
 }
 

--- a/idgenerator/aws/aws_xray_idgenerator_test.go
+++ b/idgenerator/aws/aws_xray_idgenerator_test.go
@@ -28,7 +28,7 @@ func (t traceID) convertTraceIDToHexString() string {
 	return hex.EncodeToString(t[:])
 }
 
-func (s spanID) cconvertSpanIDToHexString() string {
+func (s spanID) convertSpanIDToHexString() string {
 	return hex.EncodeToString(s[:])
 }
 
@@ -78,7 +78,7 @@ func TestAwsXRayTraceIdIsNotNil(t *testing.T) {
 
 func TestAwsXRaySpanIdIsValidLength(t *testing.T) {
 	idg := awsXRayIDGenerator()
-	spanIDHex := idg.NewSpanID().cconvertSpanIDToHexString()
+	spanIDHex := idg.NewSpanID().convertSpanIDToHexString()
 	spanIDLength := len(spanIDHex)
 	expectedSpanIDLength := 16
 
@@ -87,8 +87,8 @@ func TestAwsXRaySpanIdIsValidLength(t *testing.T) {
 
 func TestAwsXRaySpanIdIsUnique(t *testing.T) {
 	idg := awsXRayIDGenerator()
-	spanID1 := idg.NewSpanID().cconvertSpanIDToHexString()
-	spanID2 := idg.NewSpanID().cconvertSpanIDToHexString()
+	spanID1 := idg.NewSpanID().convertSpanIDToHexString()
+	spanID2 := idg.NewSpanID().convertSpanIDToHexString()
 
 	assert.NotEqual(t, spanID1, spanID2, "SpanID should be unique")
 }

--- a/idgenerator/aws/aws_xray_idgenerator_test.go
+++ b/idgenerator/aws/aws_xray_idgenerator_test.go
@@ -33,7 +33,7 @@ func (s spanID) convertSpanIDToHexString() string {
 }
 
 func TestAwsXRayTraceIdIsValidLength(t *testing.T) {
-	idg := awsXRayIDGenerator()
+	idg := XRayIDGenerator()
 	traceIDHex := idg.NewTraceID().convertTraceIDToHexString()
 	traceIDLength := len(traceIDHex)
 	expectedTraceIDLength := 32
@@ -42,7 +42,7 @@ func TestAwsXRayTraceIdIsValidLength(t *testing.T) {
 }
 
 func TestAwsXRayTraceIdIsUnique(t *testing.T) {
-	idg := awsXRayIDGenerator()
+	idg := XRayIDGenerator()
 	traceID1 := idg.NewTraceID().convertTraceIDToHexString()
 	traceID2 := idg.NewTraceID().convertTraceIDToHexString()
 
@@ -51,7 +51,7 @@ func TestAwsXRayTraceIdIsUnique(t *testing.T) {
 
 func TestAwsXRayTraceIdTimeStampInBounds(t *testing.T) {
 
-	idg := awsXRayIDGenerator()
+	idg := XRayIDGenerator()
 
 	previousTime := time.Now().Unix()
 
@@ -70,14 +70,14 @@ func TestAwsXRayTraceIdTimeStampInBounds(t *testing.T) {
 
 func TestAwsXRayTraceIdIsNotNil(t *testing.T) {
 	var nilTraceID traceID
-	idg := awsXRayIDGenerator()
+	idg := XRayIDGenerator()
 	traceID := idg.NewTraceID()
 
 	assert.False(t, bytes.Equal(traceID[:], nilTraceID[:]), "TraceID cannot be Nil.")
 }
 
 func TestAwsXRaySpanIdIsValidLength(t *testing.T) {
-	idg := awsXRayIDGenerator()
+	idg := XRayIDGenerator()
 	spanIDHex := idg.NewSpanID().convertSpanIDToHexString()
 	spanIDLength := len(spanIDHex)
 	expectedSpanIDLength := 16
@@ -86,7 +86,7 @@ func TestAwsXRaySpanIdIsValidLength(t *testing.T) {
 }
 
 func TestAwsXRaySpanIdIsUnique(t *testing.T) {
-	idg := awsXRayIDGenerator()
+	idg := XRayIDGenerator()
 	spanID1 := idg.NewSpanID().convertSpanIDToHexString()
 	spanID2 := idg.NewSpanID().convertSpanIDToHexString()
 
@@ -95,7 +95,7 @@ func TestAwsXRaySpanIdIsUnique(t *testing.T) {
 
 func TestAwsXRaySpanIdIsNotNil(t *testing.T) {
 	var nilSpanID spanID
-	idg := awsXRayIDGenerator()
+	idg := XRayIDGenerator()
 	spanID := idg.NewSpanID()
 
 	assert.False(t, bytes.Equal(spanID[:], nilSpanID[:]), "SpanID cannot be Nil.")

--- a/idgenerator/aws/go.mod
+++ b/idgenerator/aws/go.mod
@@ -1,0 +1,5 @@
+module go.opentelemetry.io/contrib/idgenerator/aws
+
+go 1.15
+
+require github.com/stretchr/testify v1.6.1

--- a/idgenerator/aws/go.sum
+++ b/idgenerator/aws/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/idgenerator/aws/go.sum
+++ b/idgenerator/aws/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR adds an ID Generator for sending traces to AWS X-Ray as well as unit tests for testing the ID Generator.

The core functionalities include:
* `NewTraceID()` which generates a new Trace ID based on [AWS X-Ray TraceID Format](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids)
* `NewSpanID` which generates a new Span ID from a randomly-chosen sequence

