### PR TITLE
Migrate CircleCI ci.yml workflow to GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,65 @@
+name: build_and_test
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        container: ["cimg/go:1.14", "cimg/go:1.15"]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container }}
+    env:
+      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+    steps:
+      - name: Setup required permissions
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: restore cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-mod
+        with:
+          path: /home/circleci/go/pkg/mod
+          key: go-pkg-mod-{{ checksum "go.sum" }}
+      - name: Precommit and Coverage Report
+        run: |
+          make ci
+          mkdir $TEST_RESULTS/
+          find . -name 'coverage.html' > "${TEST_RESULTS}/coverage.lst"
+          tar -n -cf - -T "${TEST_RESULTS}/coverage.lst" | tar -C "${TEST_RESULTS}" -xvf -
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.txt
+          fail_ci_if_error: true
+          verbose: true
+      - name: store test output
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-contrib-test-output
+            path: /tmp/test-results
+  integration:
+    strategy:
+      matrix:
+        target: [test-gocql, test-mongo-driver, test-gomemcache]
+    runs-on: ubuntu-latest
+    env:
+      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - run: mkdir -p $TEST_RESULTS
+      - name: Integration test ${{ matrix.target }}
+        run: |
+          make ${{ matrix.target }}
+          find . -name 'coverage.html' > "${TEST_RESULTS}/coverage.lst"
+          tar -n -cf - -T "${TEST_RESULTS}/coverage.lst" | tar -C "${TEST_RESULTS}" -xvf -
+      - name: store test output
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-contrib-test-output
+            path: /tmp/test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The AWS detector now adds the cloud zone, host image ID, host type, and host name to the returned `Resource`. (#410)
 - Add Amazon ECS Resource Detector for AWS X-Ray. (#466)
 - Add propagator for AWS X-Ray (#462)
-  
+- Migrate CircleCI jobs to GitHub Actions (#ADD NUMBER WHEN PR IS MADE UPSTREAM)
 ### Changed
 
 - Add semantic version to `Tracer` / `Meter` created by instrumentation packages `otelsaram`, `otelrestful`, `otelmongo`, `otelhttp` and `otelhttptrace`. (#412)


### PR DESCRIPTION
### What does this do

This  addresses issue https://github.com/open-telemetry/opentelemetry-go/issues/880 by migrating CI/CD from CircleCI to GitHub Actions

### Changes

* Migrated `current-go`, `prior-go` and `integration-test` CircleCI jobs to GitHub Actions. 
* Changelog updated

### Migration Plan
I suggest having CircleCI and GitHub Action jobs run in parallel for a few weeks. After the GitHub Actions jobs are running fine for a week or so, remove the CircleCI workflows from `config.yml`

cc- @alolita 