### PR TITLE
Adding Security Workflows to GitHub Actions (1/2): codeql workflow

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 1 * * *'
+
+jobs:
+  CodeQL-Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -1,8 +1,5 @@
 on:
   push:
-    branches: [master]
-  pull_request:
-    branches: [master]
   workflow_dispatch:
   schedule:
     #        ┌───────────── minute (0 - 59)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add registry link check to `Makefile` and pre-release script. (#446)
 - A new AWS X-Ray ID Generator (#459)
 - Migrate CircleCI jobs to GitHub Actions (#476)
+- Add CodeQL GitHub Action (#TBD)
+
 ### Fixed
 
 - Fixes the body replacement in otelhttp to not to mutate a nil body. (#484)


### PR DESCRIPTION
## Motivation
Follow up to issue Follow up to issue https://github.com/open-telemetry/oteps/issues/144 


[CodeQL](https://github.com/github/codeql-action) is GitHub's static analysis engine which scans repos for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities with every PR so we can ensure every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users. 

## Changes

* This PR adds [CodeQL](https://github.com/github/codeql-action) security checks to the repo
* After every run the workflow uploads the results to GitHub. Details on the run and security alerts will show up in the `security` tab of this repo. 

**Workflow Triggers**
* daily cron job at 1:30am
* workflow_dispatch (in case maintainers want to trigger a security check manually)

cc- @alolita 