### PR TITLE
Added guard to prevent Options from setting nil providers

### DIFF
--- a/instrumentation/github.com/Shopify/sarama/otelsarama/option.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/option.go
@@ -63,7 +63,9 @@ func (fn optionFunc) apply(c *config) {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
 	})
 }
 

--- a/instrumentation/github.com/astaxie/beego/otelbeego/config.go
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/config.go
@@ -52,7 +52,9 @@ func (o optionFunc) apply(c *config) {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.tracerProvider = provider
+		if provider != nil {
+			cfg.tracerProvider = provider
+		}
 	})
 }
 
@@ -60,7 +62,9 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 // If none is specified, the global provider is used.
 func WithMeterProvider(provider metric.MeterProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.meterProvider = provider
+		if provider != nil {
+			cfg.meterProvider = provider
+		}
 	})
 }
 

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/config.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/config.go
@@ -39,6 +39,8 @@ func (o optionFunc) apply(c *config) {
 // If none is specified, the global TracerProvider is used.
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
 	})
 }

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/config.go
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/config.go
@@ -37,6 +37,8 @@ func (o optionFunc) apply(c *config) {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.tracerProvider = provider
+		if provider != nil {
+			cfg.tracerProvider = provider
+		}
 	})
 }

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/config.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/config.go
@@ -49,6 +49,8 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
 	})
 }

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
@@ -50,6 +50,8 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
 	})
 }

--- a/instrumentation/github.com/go-kit/kit/otelkit/config.go
+++ b/instrumentation/github.com/go-kit/kit/otelkit/config.go
@@ -64,7 +64,9 @@ func (o optionFunc) apply(c *config) {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(o *config) {
-		o.TracerProvider = provider
+		if provider != nil {
+			o.TracerProvider = provider
+		}
 	})
 }
 

--- a/instrumentation/github.com/gocql/gocql/otelgocql/config.go
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/config.go
@@ -76,7 +76,9 @@ func WithConnectObserver(observer gocql.ConnectObserver) Option {
 // for creating spans. Defaults to TracerProvider()
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(c *config) {
-		c.tracerProvider = provider
+		if provider != nil {
+			c.tracerProvider = provider
+		}
 	})
 }
 
@@ -85,7 +87,9 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 // Defaults to global.GetMeterProvider().
 func WithMeterProvider(provider metric.MeterProvider) Option {
 	return optionFunc(func(c *config) {
-		c.meterProvider = provider
+		if provider != nil {
+			c.meterProvider = provider
+		}
 	})
 }
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/config.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/config.go
@@ -49,6 +49,8 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
 	})
 }

--- a/instrumentation/github.com/labstack/echo/otelecho/config.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/config.go
@@ -52,7 +52,9 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
 	})
 }
 

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/config.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/config.go
@@ -62,7 +62,9 @@ func (o optionFunc) apply(c *config) {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
 	})
 }
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/grpctrace.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/grpctrace.go
@@ -71,7 +71,9 @@ func WithPropagators(p propagation.TextMapPropagator) Option {
 type tracerProviderOption struct{ tp trace.TracerProvider }
 
 func (o tracerProviderOption) apply(c *config) {
-	c.TracerProvider = o.tp
+	if o.tp != nil {
+		c.TracerProvider = o.tp
+	}
 }
 
 // WithTracerProvider returns an Option to use the TracerProvider when

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/config.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/config.go
@@ -58,7 +58,9 @@ func WithPropagators(p propagation.TextMapPropagator) Option {
 type tracerProviderOption struct{ tp trace.TracerProvider }
 
 func (o tracerProviderOption) apply(c *config) {
-	c.TracerProvider = o.tp
+	if o.tp != nil {
+		c.TracerProvider = o.tp
+	}
 }
 
 // WithTracerProvider returns an Option to use the TracerProvider when

--- a/instrumentation/host/host.go
+++ b/instrumentation/host/host.go
@@ -61,7 +61,9 @@ func WithMeterProvider(provider metric.MeterProvider) Option {
 type metricProviderOption struct{ metric.MeterProvider }
 
 func (o metricProviderOption) apply(c *config) {
-	c.MeterProvider = o.MeterProvider
+	if o.MeterProvider != nil {
+		c.MeterProvider = o.MeterProvider
+	}
 }
 
 // Attribute sets.

--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -83,7 +83,9 @@ func newConfig(opts ...Option) *config {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
 	})
 }
 
@@ -91,7 +93,9 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 // If none is specified, the global provider is used.
 func WithMeterProvider(provider metric.MeterProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.MeterProvider = provider
+		if provider != nil {
+			cfg.MeterProvider = provider
+		}
 	})
 }
 

--- a/instrumentation/runtime/runtime.go
+++ b/instrumentation/runtime/runtime.go
@@ -80,7 +80,9 @@ func WithMeterProvider(provider metric.MeterProvider) Option {
 type metricProviderOption struct{ metric.MeterProvider }
 
 func (o metricProviderOption) apply(c *config) {
-	c.MeterProvider = o.MeterProvider
+	if o.MeterProvider != nil {
+		c.MeterProvider = o.MeterProvider
+	}
 }
 
 // newConfig computes a config from the supplied Options.


### PR DESCRIPTION
**Description:**
This PR adds a guard to prevent options from setting nil providers, in the form of a `if provider != nil` check.

**Link to tracking Issue:**
[1104](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/1104)