### PR TITLE
Added guard to prevent Options from setting nil Propagators

### DIFF
--- a/instrumentation/github.com/Shopify/sarama/otelsarama/option.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/option.go
@@ -72,6 +72,8 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 // ones will be used.
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.Propagators = propagators
+		if propagators != nil {
+			cfg.Propagators = propagators
+		}
 	})
 }

--- a/instrumentation/github.com/astaxie/beego/otelbeego/config.go
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/config.go
@@ -68,7 +68,9 @@ func WithMeterProvider(provider metric.MeterProvider) Option {
 // Defaults to global.Propagators().
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
 	return optionFunc(func(c *config) {
-		c.propagators = propagators
+		if propagators != nil {
+			c.propagators = propagators
+		}
 	})
 }
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/config.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/config.go
@@ -41,7 +41,9 @@ func (o optionFunc) apply(c *config) {
 // ones will be used.
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.Propagators = propagators
+		if propagators != nil {
+			cfg.Propagators = propagators
+		}
 	})
 }
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
@@ -42,7 +42,9 @@ func (o optionFunc) apply(c *config) {
 // ones will be used.
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.Propagators = propagators
+		if propagators != nil {
+			cfg.Propagators = propagators
+		}
 	})
 }
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/config.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/config.go
@@ -41,7 +41,9 @@ func (o optionFunc) apply(c *config) {
 // ones will be used.
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.Propagators = propagators
+		if propagators != nil {
+			cfg.Propagators = propagators
+		}
 	})
 }
 

--- a/instrumentation/github.com/labstack/echo/otelecho/config.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/config.go
@@ -44,7 +44,9 @@ func (o optionFunc) apply(c *config) {
 // ones will be used.
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.Propagators = propagators
+		if propagators != nil {
+			cfg.Propagators = propagators
+		}
 	})
 }
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/grpctrace.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/grpctrace.go
@@ -59,7 +59,9 @@ func newConfig(opts []Option) *config {
 type propagatorsOption struct{ p propagation.TextMapPropagator }
 
 func (o propagatorsOption) apply(c *config) {
-	c.Propagators = o.p
+	if o.p != nil {
+		c.Propagators = o.p
+	}
 }
 
 // WithPropagators returns an Option to use the Propagators when extracting

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/config.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/config.go
@@ -46,7 +46,9 @@ func newConfig(opts []Option) *config {
 type propagatorsOption struct{ p propagation.TextMapPropagator }
 
 func (o propagatorsOption) apply(c *config) {
-	c.Propagators = o.p
+	if o.p != nil {
+		c.Propagators = o.p
+	}
 }
 
 // WithPropagators returns an Option to use the Propagators when extracting

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
@@ -53,7 +53,9 @@ func newConfig(opts []Option) *config {
 // WithPropagators sets the propagators to use for Extraction and Injection
 func WithPropagators(props propagation.TextMapPropagator) Option {
 	return optionFunc(func(c *config) {
-		c.propagators = props
+		if props != nil {
+			c.propagators = props
+		}
 	})
 }
 

--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -108,7 +108,9 @@ func WithPublicEndpoint() Option {
 // option isn't specified, then the global TextMapPropagator is used.
 func WithPropagators(ps propagation.TextMapPropagator) Option {
 	return optionFunc(func(c *config) {
-		c.Propagators = ps
+		if ps != nil {
+			c.Propagators = ps
+		}
 	})
 }
 


### PR DESCRIPTION
**Description:**
This PR adds a guard to prevent options from setting nil propagators, in the form of a `if propagator != nil` check.

**Link to tracking Issue:**
[1108](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/1108)