### PR TITLE
Add WithTracerProvider func to httptrace package

### DIFF
--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
@@ -39,7 +39,8 @@ func (o optionFunc) apply(c *config) {
 }
 
 type config struct {
-	propagators propagation.TextMapPropagator
+	tracerProvider 	trace.TracerProvider
+	propagators 	propagation.TextMapPropagator
 }
 
 func newConfig(opts []Option) *config {
@@ -48,6 +49,16 @@ func newConfig(opts []Option) *config {
 		o.apply(c)
 	}
 	return c
+}
+
+// WithTracerProvider specifies a tracer provider for creating a tracer.
+// The global provider is used if none is specified.
+func WithTracerProvider(provider trace.TracerProvider) Option {
+	return optionFunc(func(cfg *config) {
+		if provider != nil {
+			cfg.tracerProvider = provider
+		}
+	})
 }
 
 // WithPropagators sets the propagators to use for Extraction and Injection


### PR DESCRIPTION
**Description:**
This PR adds the `WithTracerProvider()` function to the `httptrace` package.

**Link to tracking Issue:**
[1105](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/1105)