### PR TITLE
modified otel-http-server-duration from microseconds to milliseconds

### DIFF
--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -48,7 +48,7 @@ type Handler struct {
 	filters           []Filter
 	spanNameFormatter func(string, *http.Request) string
 	counters          map[string]metric.Int64Counter
-	valueRecorders    map[string]metric.Int64Histogram
+	valueRecorders    map[string]metric.Float64Histogram
 }
 
 func defaultHandlerFormatter(operation string, _ *http.Request) string {
@@ -94,7 +94,7 @@ func handleErr(err error) {
 
 func (h *Handler) createMeasures() {
 	h.counters = make(map[string]metric.Int64Counter)
-	h.valueRecorders = make(map[string]metric.Int64Histogram)
+	h.valueRecorders = make(map[string]metric.Float64Histogram)
 
 	requestBytesCounter, err := h.meter.NewInt64Counter(RequestContentLength)
 	handleErr(err)
@@ -102,7 +102,7 @@ func (h *Handler) createMeasures() {
 	responseBytesCounter, err := h.meter.NewInt64Counter(ResponseContentLength)
 	handleErr(err)
 
-	serverLatencyMeasure, err := h.meter.NewInt64Histogram(ServerLatency)
+	serverLatencyMeasure, err := h.meter.NewFloat64Histogram(ServerLatency)
 	handleErr(err)
 
 	h.counters[RequestContentLength] = requestBytesCounter
@@ -195,7 +195,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.counters[RequestContentLength].Add(ctx, bw.read, attributes...)
 	h.counters[ResponseContentLength].Add(ctx, rww.written, attributes...)
 
-	elapsedTime := time.Since(requestStartTime).Microseconds()
+	elapsedTime := float64(time.Since(requestStartTime)) / float64(time.Millisecond)
 
 	h.valueRecorders[ServerLatency].Record(ctx, elapsedTime, attributes...)
 }


### PR DESCRIPTION
Description:
This PR is to modify otel http server duration from microseconds to milliseconds as per the [specs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md) mentioned in OpenTelemetry Go. 

Link to tracking Issue:
issue # 1335 